### PR TITLE
Fix GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,8 @@
 name: Deploy to GitHub Pages
 
 on:
+  push:
+    branches: [ main ]
   workflow_dispatch:
 
 permissions:
@@ -9,175 +11,59 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
+  group: pages
   cancel-in-progress: false
 
 jobs:
-  prepare-data:
+  build:
     runs-on: ubuntu-latest
-    outputs:
-      data-ready: ${{ steps.data-check.outputs.ready }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-        cache: 'npm'
-        
-    - name: Install dependencies
-      run: npm ci
-      
-    - name: Generate static data
-      run: npx tsx scripts/build-static.ts
-      env:
-        VITE_STATIC_BUILD: 'true'
-        
-    - name: Cache static data
-      uses: actions/cache@v3
-      with:
-        path: |
-          client/public/data
-          dist
-        key: static-data-${{ github.sha }}
-        
-    - name: Check data preparation
-      id: data-check
-      run: echo "ready=true" >> $GITHUB_OUTPUT
+      - name: Checkout
+        uses: actions/checkout@v4
 
-  build-dependencies:
-    runs-on: ubuntu-latest
-    needs: prepare-data
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-        cache: 'npm'
-        
-    - name: Install dependencies
-      run: npm ci
-      
-    - name: Cache node_modules
-      uses: actions/cache@v3
-      with:
-        path: node_modules
-        key: deps-${{ github.sha }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
 
-  build-core:
-    runs-on: ubuntu-latest
-    needs: [prepare-data, build-dependencies]
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-        
-    - name: Restore dependencies
-      uses: actions/cache@v3
-      with:
-        path: node_modules
-        key: deps-${{ github.sha }}
-        
-    - name: Restore static data
-      uses: actions/cache@v3
-      with:
-        path: |
-          client/public/data
-          dist
-        key: static-data-${{ github.sha }}
-        
-    - name: Build React core (step 1)
-      timeout-minutes: 25
-      run: |
-        export NODE_OPTIONS="--max-old-space-size=8192"
-        # Attempt Vite build with timeout protection
-        timeout 1200s npx vite build --mode production --logLevel error --minify false || {
-          echo "Vite build timed out, using deploy-simple fallback..."
-          npx tsx scripts/deploy-simple.ts
-        }
-      env:
-        NODE_ENV: 'production'
-        VITE_STATIC_BUILD: 'true'
-        VITE_GA_MEASUREMENT_ID: ${{ secrets.GA_MEASUREMENT_ID }}
-        VITE_SITE_TITLE: ${{ vars.SITE_TITLE || 'Awesome Video Dashboard' }}
-        VITE_SITE_DESCRIPTION: ${{ vars.SITE_DESCRIPTION || 'A curated collection of awesome video resources and tools' }}
-        VITE_SITE_URL: ${{ vars.SITE_URL || 'https://krzemienski.github.io/awesome-list-site' }}
-        VITE_DEFAULT_THEME: ${{ vars.DEFAULT_THEME || 'red' }}
-        
-    - name: Cache core build
-      uses: actions/cache@v3
-      with:
-        path: dist
-        key: build-core-${{ github.sha }}
+      - name: Install dependencies
+        run: npm ci
 
-  optimize-build:
-    runs-on: ubuntu-latest
-    needs: build-core
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-        
-    - name: Restore core build
-      uses: actions/cache@v3
-      with:
-        path: dist
-        key: build-core-${{ github.sha }}
-        
-    - name: Optimize assets (step 2)
-      timeout-minutes: 10
-      run: |
-        # Minify and optimize the built assets
-        if [ -d "dist/public/assets" ]; then
-          echo "Optimizing CSS and JS assets..."
-          # Could add additional optimization here if needed
-        fi
-        echo "Asset optimization complete"
-        
-    - name: Cache optimized build
-      uses: actions/cache@v3
-      with:
-        path: dist
-        key: build-optimized-${{ github.sha }}
+      - name: Generate static data
+        run: npx tsx scripts/build-static.ts
+        env:
+          VITE_STATIC_BUILD: 'true'
 
-  deploy:
-    runs-on: ubuntu-latest
-    needs: [prepare-data, optimize-build]
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      
-    - name: Restore build artifacts
-      uses: actions/cache@v3
-      with:
-        path: dist
-        key: build-optimized-${{ github.sha }}
-        
-    - name: Setup Pages
-      uses: actions/configure-pages@v4
-      
-    - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
-      with:
-        path: './dist/public'
-        
-    - name: Deploy to GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@v4
-      with:
-        artifact_name: github-pages
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build static site
+        run: npx tsx scripts/build-react-static.ts
+        env:
+          NODE_ENV: 'production'
+          VITE_STATIC_BUILD: 'true'
+          VITE_GA_MEASUREMENT_ID: ${{ secrets.GA_MEASUREMENT_ID }}
+
+      - name: Normalize output path
+        run: |
+          if [ -f dist/index.html ] && [ ! -f dist/public/index.html ]; then
+            mkdir -p dist/public
+            mv dist/index.html dist/public/index.html
+            if [ -d dist/data ]; then
+              mv dist/data dist/public/data
+            fi
+          fi
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist/public
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+        with:
+          artifact_name: github-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- streamline GitHub Pages workflow
- use build-static and build-react-static scripts
- handle fallback build output

## Testing
- `npm run build`
- `npx tsx scripts/build-static.ts` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684cf3f4a6588320a92760eca4dfcf97

## Summary by Sourcery

Streamline GitHub Pages deployment by merging multiple workflow jobs into a single build job that runs on pushes to main, leverages dedicated static/build scripts, and normalizes output paths for fallback compatibility.

Bug Fixes:
- Normalize build output to dist/public to prevent missing files when deploying to GitHub Pages

Enhancements:
- Consolidate preparation, build, optimization, and deployment steps into one job
- Replace direct Vite invocations with scripts/build-static.ts and scripts/build-react-static.ts
- Simplify concurrency syntax and remove redundant cache and checkout steps

CI:
- Add push trigger for the main branch
- Combine all workflow actions under a unified build job

Deployment:
- Use configure-pages, upload-pages-artifact, and deploy-pages actions within the consolidated job