### PR TITLE
Set up dev environment: fix lockfile registry + add Cursor Cloud notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a single full-stack app ("Awesome Video Resource Viewer", package name `rest-express`):
+Express + Vite/React (one process) backed by PostgreSQL via Drizzle ORM. The Express
+server also serves the frontend, so there is only **one app service** plus a **database**.
+
+Standard commands live in `package.json` scripts and are documented in `README.md`,
+`DEVELOPMENT.md`, and `docs/SETUP.md` / `docs/ENVIRONMENT_VARIABLES.md`. Only the
+non-obvious, environment-specific caveats are captured here.
+
+### Package manager
+- Use **npm** (there is a `package-lock.json`; the `pnpm-lock.yaml` in the repo is stale — ignore it).
+- The committed lockfile originally pointed 41 `resolved` URLs at a dead Replit-internal
+  registry (`package-firewall.replit.local`); these have been rewritten to
+  `registry.npmjs.org`. If you ever regenerate the lockfile, do not reintroduce that host.
+
+### PostgreSQL (must be running before the app or tests)
+- Postgres 16 is installed locally (not Docker). It does **not** auto-start on a fresh VM boot.
+  Start it each session with: `sudo pg_ctlcluster 16 main start`
+- Connection (already in `.env`): `postgresql://postgres:postgres@127.0.0.1:5432/awesome_list`
+  (role `postgres`, password `postgres`, database `awesome_list`).
+- `.env` is git-ignored and persists in the VM snapshot (contains `DATABASE_URL` and a
+  generated `SESSION_SECRET`). If it is ever missing, recreate it with those two vars plus
+  `NODE_ENV=development` and `PORT=5000`.
+
+### Running the app
+- `npm run dev` → http://localhost:5000 (API + frontend via Vite middleware, HMR enabled).
+- On first startup against an empty DB the server **auto-seeds** ~1,900+ resources /
+  9 categories from the upstream awesome-video list (takes ~20s; watch the startup logs).
+  Migrations only run automatically in `NODE_ENV=production`; in dev the schema is applied
+  via `npm run db:push`.
+
+### Auth / admin
+- Local email/password auth is used (Replit OAuth is disabled off-Replit).
+- No admin user is seeded unless `ADMIN_PASSWORD` is set before the first seed. To get one:
+  set `ADMIN_PASSWORD` and reseed, OR register any user (UI "Create account" or
+  `POST /api/auth/register`) and promote it via SQL: `UPDATE users SET role='admin' WHERE email='...';`
+- `scripts/reset-admin-password.ts` only *updates* an existing `admin@example.com`; it does not create one.
+
+### Lint / build / test status (baseline on `main`)
+- `npm run build` — passes. `npm run type-check` (`tsc --noEmit`) — passes.
+- `npm run lint` — currently reports many **pre-existing** errors (unrelated to env setup); it runs fine.
+- `npm run test:e2e` — Playwright; the Chromium binary is installed and the config reuses the
+  running dev server on :5000. Works (e.g. `tests/e2e/favorites.spec.ts` is green).
+- `npm run test:unit` / `npm run test:integration` — currently **fail to start**: `vitest` is
+  referenced by the scripts but is **not declared** in `package.json` (pre-existing gap).
+  The vitest harness would auto-provision an `awesome_list_test` database from the `postgres`
+  maintenance DB if vitest were installed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -163,7 +163,7 @@
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
       "version": "0.3.201",
-      "resolved": "http://package-firewall.replit.local/npm/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.201.tgz",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.201.tgz",
       "integrity": "sha512-InT1XLmf2QpldWdtznKDWEoGJT4p+sXh24yxbeBQ++lMJCzMrI0W27MEmmmDWx0otpa+ubdHCF5YQ6oiNt7cmg==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
@@ -187,7 +187,7 @@
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
       "version": "0.3.201",
-      "resolved": "http://package-firewall.replit.local/npm/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.201.tgz",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.201.tgz",
       "integrity": "sha512-8Mcb3BDyKUGfJWFFTWwt+at37lbDH3ZwVtUNPWGG1toZ75RDCJry5U4kXRvQ2xokvJQlA0E+eNp6keWe5ZH22Q==",
       "cpu": [
         "arm64"
@@ -200,7 +200,7 @@
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
       "version": "0.3.201",
-      "resolved": "http://package-firewall.replit.local/npm/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.201.tgz",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.201.tgz",
       "integrity": "sha512-TFR2bu0+ml3RHoMrtsgD0qDK5Oknw8kYGBV7qpQHn+IWmE96gnHhogG1LpJwpHtni08XkJIjfWk1DdlsUYtRkQ==",
       "cpu": [
         "x64"
@@ -213,7 +213,7 @@
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
       "version": "0.3.201",
-      "resolved": "http://package-firewall.replit.local/npm/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.201.tgz",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.201.tgz",
       "integrity": "sha512-mShTo3MwF0gkN4dDw78wWJiB6aBDVRkl81cnApvoBofpdyUBYgm9Gw16CCjDTgelMKeBFqN6ErJpwjI3wbP00A==",
       "cpu": [
         "arm64"
@@ -226,7 +226,7 @@
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
       "version": "0.3.201",
-      "resolved": "http://package-firewall.replit.local/npm/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.201.tgz",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.201.tgz",
       "integrity": "sha512-EiqbpfJIpChfkn+8Uj061Qjyw0eaRcOXtdrvVuHANyj8ZErVOr8HlH6op9PSeIUa9TX0m2+tNgKPQvOGseQckA==",
       "cpu": [
         "arm64"
@@ -239,7 +239,7 @@
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
       "version": "0.3.201",
-      "resolved": "http://package-firewall.replit.local/npm/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.201.tgz",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.201.tgz",
       "integrity": "sha512-jrJBrRWrSuoFKIgjyqxHqmfd6Pb3Bs5Bvakg0knXCTC4fbUXGnC9Q6u7gdDwgXohUNP6/DD+s8U7bivvvVv0dg==",
       "cpu": [
         "x64"
@@ -252,7 +252,7 @@
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
       "version": "0.3.201",
-      "resolved": "http://package-firewall.replit.local/npm/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.201.tgz",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.201.tgz",
       "integrity": "sha512-IbxnzO5UCbqbm2TnzCHkSyJorAFw2isdKdIsFCTxJJjSs3ZC+v3LC1QSUiVCx0qi+CV6w3MKx6mLI11mrvhbbQ==",
       "cpu": [
         "x64"
@@ -265,7 +265,7 @@
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
       "version": "0.3.201",
-      "resolved": "http://package-firewall.replit.local/npm/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.201.tgz",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.201.tgz",
       "integrity": "sha512-UsoytRJ/037uHpb3ATrIoe+AgwTf+PwKuFLGjddHAV/11wERJs0hlrnSmcnp43kf0PFxoSNinngme96YYASmQg==",
       "cpu": [
         "arm64"
@@ -278,7 +278,7 @@
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
       "version": "0.3.201",
-      "resolved": "http://package-firewall.replit.local/npm/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.201.tgz",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.201.tgz",
       "integrity": "sha512-PhalN/0cWcqDfbx7iwoLNR2gurjTiqhBk1G6K+NRScxEcQjWuu5xKXCcdbX8ePVpT+nbEMmFEFpn2y+8V8hIdA==",
       "cpu": [
         "x64"
@@ -291,7 +291,7 @@
     },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.110.0",
-      "resolved": "http://package-firewall.replit.local/npm/@anthropic-ai/sdk/-/sdk-0.110.0.tgz",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.110.0.tgz",
       "integrity": "sha512-hOP4bNYXDFHDxxiEgzlILXrxZIYCDnhe8sry0RDRKD/QnsEpvZcQpablCdm9X/WuD/YgOiSIkkqsL1mLLlTqJw==",
       "license": "MIT",
       "dependencies": {
@@ -2586,7 +2586,7 @@
     },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
-      "resolved": "http://package-firewall.replit.local/npm/@noble/hashes/-/hashes-1.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "dev": true,
       "license": "MIT",
@@ -2753,7 +2753,7 @@
     },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
-      "resolved": "http://package-firewall.replit.local/npm/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
       "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
       "dev": true,
       "license": "MIT",
@@ -2770,7 +2770,7 @@
     },
     "node_modules/@playwright/test": {
       "version": "1.60.0",
-      "resolved": "http://package-firewall.replit.local/npm/@playwright/test/-/test-1.60.0.tgz",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
       "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
@@ -4848,7 +4848,7 @@
     },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",
-      "resolved": "http://package-firewall.replit.local/npm/@stablelib/base64/-/base64-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
@@ -5250,7 +5250,7 @@
     },
     "node_modules/@types/cookiejar": {
       "version": "2.1.5",
-      "resolved": "http://package-firewall.replit.local/npm/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
       "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
       "dev": true,
       "license": "MIT"
@@ -5407,7 +5407,7 @@
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
-      "resolved": "http://package-firewall.replit.local/npm/@types/methods/-/methods-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
       "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
       "dev": true,
       "license": "MIT"
@@ -5553,7 +5553,7 @@
     },
     "node_modules/@types/superagent": {
       "version": "8.1.10",
-      "resolved": "http://package-firewall.replit.local/npm/@types/superagent/-/superagent-8.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.10.tgz",
       "integrity": "sha512-nbt4IWXABhW0jGmmpRzCFNlbmwCTzZ2gTUsNIr+X+ItdqPms+PAJZbWsNzpS2USqXjcoNLQcO6nXo60zcPQiIg==",
       "dev": true,
       "license": "MIT",
@@ -5566,7 +5566,7 @@
     },
     "node_modules/@types/supertest": {
       "version": "6.0.3",
-      "resolved": "http://package-firewall.replit.local/npm/@types/supertest/-/supertest-6.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
       "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
       "dev": true,
       "license": "MIT",
@@ -6191,7 +6191,7 @@
     },
     "node_modules/asap": {
       "version": "2.0.6",
-      "resolved": "http://package-firewall.replit.local/npm/asap/-/asap-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true,
       "license": "MIT"
@@ -6846,7 +6846,7 @@
     },
     "node_modules/component-emitter": {
       "version": "1.3.1",
-      "resolved": "http://package-firewall.replit.local/npm/component-emitter/-/component-emitter-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
       "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
       "dev": true,
       "license": "MIT",
@@ -6918,7 +6918,7 @@
     },
     "node_modules/cookiejar": {
       "version": "2.1.4",
-      "resolved": "http://package-firewall.replit.local/npm/cookiejar/-/cookiejar-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true,
       "license": "MIT"
@@ -7468,7 +7468,7 @@
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
-      "resolved": "http://package-firewall.replit.local/npm/dezalgo/-/dezalgo-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
       "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
       "dev": true,
       "license": "ISC",
@@ -9108,14 +9108,14 @@
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
-      "resolved": "http://package-firewall.replit.local/npm/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-sha256": {
       "version": "1.3.0",
-      "resolved": "http://package-firewall.replit.local/npm/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
       "license": "Unlicense"
     },
@@ -9327,7 +9327,7 @@
     },
     "node_modules/formidable": {
       "version": "3.5.4",
-      "resolved": "http://package-firewall.replit.local/npm/formidable/-/formidable-3.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
       "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
       "dev": true,
       "license": "MIT",
@@ -10583,7 +10583,7 @@
     },
     "node_modules/json-schema-to-ts": {
       "version": "3.1.1",
-      "resolved": "http://package-firewall.replit.local/npm/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
       "license": "MIT",
       "dependencies": {
@@ -11690,7 +11690,7 @@
     },
     "node_modules/nanoid": {
       "version": "5.1.11",
-      "resolved": "http://package-firewall.replit.local/npm/nanoid/-/nanoid-5.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
       "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
       "funding": [
         {
@@ -12162,7 +12162,7 @@
     },
     "node_modules/next/node_modules/nanoid": {
       "version": "3.3.12",
-      "resolved": "http://package-firewall.replit.local/npm/nanoid/-/nanoid-3.3.12.tgz",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
       "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
@@ -12874,7 +12874,7 @@
     },
     "node_modules/pg": {
       "version": "8.20.0",
-      "resolved": "http://package-firewall.replit.local/npm/pg/-/pg-8.20.0.tgz",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
       "dependencies": {
@@ -12908,7 +12908,7 @@
     },
     "node_modules/pg-connection-string": {
       "version": "2.13.0",
-      "resolved": "http://package-firewall.replit.local/npm/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
       "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
       "license": "MIT"
     },
@@ -12932,7 +12932,7 @@
     },
     "node_modules/pg-pool": {
       "version": "3.14.0",
-      "resolved": "http://package-firewall.replit.local/npm/pg-pool/-/pg-pool-3.14.0.tgz",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
       "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
       "license": "MIT",
       "peerDependencies": {
@@ -12941,7 +12941,7 @@
     },
     "node_modules/pg-protocol": {
       "version": "1.14.0",
-      "resolved": "http://package-firewall.replit.local/npm/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
       "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
       "license": "MIT"
     },
@@ -13048,7 +13048,7 @@
     },
     "node_modules/playwright": {
       "version": "1.60.0",
-      "resolved": "http://package-firewall.replit.local/npm/playwright/-/playwright-1.60.0.tgz",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
       "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -13067,7 +13067,7 @@
     },
     "node_modules/playwright-core": {
       "version": "1.60.0",
-      "resolved": "http://package-firewall.replit.local/npm/playwright-core/-/playwright-core-1.60.0.tgz",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
       "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -13125,7 +13125,7 @@
     },
     "node_modules/postcss/node_modules/nanoid": {
       "version": "3.3.12",
-      "resolved": "http://package-firewall.replit.local/npm/nanoid/-/nanoid-3.3.12.tgz",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
       "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
@@ -14351,7 +14351,7 @@
     },
     "node_modules/standardwebhooks": {
       "version": "1.0.0",
-      "resolved": "http://package-firewall.replit.local/npm/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
       "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
       "license": "MIT",
       "dependencies": {
@@ -14555,7 +14555,7 @@
     },
     "node_modules/superagent": {
       "version": "10.3.0",
-      "resolved": "http://package-firewall.replit.local/npm/superagent/-/superagent-10.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
       "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
       "dev": true,
       "license": "MIT",
@@ -14576,7 +14576,7 @@
     },
     "node_modules/superagent/node_modules/mime": {
       "version": "2.6.0",
-      "resolved": "http://package-firewall.replit.local/npm/mime/-/mime-2.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
       "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
       "dev": true,
       "license": "MIT",
@@ -14589,7 +14589,7 @@
     },
     "node_modules/supertest": {
       "version": "7.2.2",
-      "resolved": "http://package-firewall.replit.local/npm/supertest/-/supertest-7.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
       "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
       "dev": true,
       "license": "MIT",
@@ -14604,7 +14604,7 @@
     },
     "node_modules/supertest/node_modules/cookie-signature": {
       "version": "1.2.2",
-      "resolved": "http://package-firewall.replit.local/npm/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "dev": true,
       "license": "MIT",
@@ -14867,7 +14867,7 @@
     },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
-      "resolved": "http://package-firewall.replit.local/npm/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "license": "MIT"
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the Awesome Video Resource Viewer (Express + Vite/React + PostgreSQL/Drizzle) so lint, build, type-check, e2e tests, and the app itself all run in a clean cloud VM.

Only two files change; no application code was modified.

### Changes
- **`package-lock.json`**: rewrote 41 `resolved` URLs that pointed at a dead Replit-internal npm mirror (`package-firewall.replit.local`) to `registry.npmjs.org`. These were causing `npm ci` to fail with `EAI_AGAIN` DNS errors off-Replit. Integrity hashes are content-based and unchanged, so the resolved tarballs are identical.
- **`AGENTS.md`** (new): adds a `## Cursor Cloud specific instructions` section documenting the single app + Postgres service model, how to start local Postgres, the auto-seed behavior, auth/admin notes, and the current lint/test baseline.

### Environment setup performed (not committed)
- Installed Node deps via `npm ci` (npm; `pnpm-lock.yaml` is stale and ignored).
- Installed PostgreSQL 16 locally, created the `awesome_list` DB, applied schema via `drizzle-kit push`.
- Created a git-ignored `.env` (`DATABASE_URL`, generated `SESSION_SECRET`, `NODE_ENV=development`, `PORT=5000`).
- Update script for future sessions: `npm install`.

### Verification
- ✅ `npm run build`
- ✅ `npm run type-check`
- ✅ `npm run test:e2e -- --project=chromium tests/e2e/favorites.spec.ts` (27/27 passed)
- ⚠️ `npm run lint` — runs, but reports pre-existing errors unrelated to this change.
- ⚠️ `npm run test:unit` / `test:integration` — fail because `vitest` is referenced by the scripts but not declared in `package.json` (pre-existing gap).

Hello-world flow verified end-to-end in the browser: homepage → search "FFMPEG" → register `demo-user@example.com` → auto-login → bookmark a resource → see it on the Bookmarks page.

[hello_world_register_search_bookmark.mp4](https://cursor.com/agents/bc-9cf0c020-e9e4-4f41-b1b3-14d0b48d4be0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_register_search_bookmark.mp4)

[Homepage](https://cursor.com/agents/bc-9cf0c020-e9e4-4f41-b1b3-14d0b48d4be0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_loaded.webp)
[Bookmarks page with saved resource](https://cursor.com/agents/bc-9cf0c020-e9e4-4f41-b1b3-14d0b48d4be0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbookmarks_page.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9cf0c020-e9e4-4f41-b1b3-14d0b48d4be0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cf0c020-e9e4-4f41-b1b3-14d0b48d4be0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Document Cursor Cloud-specific dev environment setup and fix npm lockfile registry URLs to work outside Replit.

Enhancements:
- Update npm lockfile to replace dead Replit-internal registry URLs with public npm registry endpoints.

Documentation:
- Add AGENTS.md with Cursor Cloud-specific instructions for running the app, PostgreSQL, auth, and the current lint/test baseline.